### PR TITLE
Finish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # hello-world
 jeet repository
+Hi world,
+jeet here,the grid view v1.37 is appearing in the form of column while launching in google meet. 
+All the participants are not visible in the tiled format. 


### PR DESCRIPTION
previously the Grid view was showing all the participants in the tiled view. From day before yesterday it has changed to a column view. Need to be able to view all students in tiled format. Participants more than 60 at a time.